### PR TITLE
Initial packaging for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,11 @@ It also serves as a platform for other scripts - if we can write a script that w
 
 Setup
 -----
-Allgit expects to find Python 3.6+ in the path as `python3`.  Note that `python3` does _not_ have to be your default python, it just has to be installed.
+_(( Is this going to be needed in a packaged world? ))_ Allgit expects to find Python 3.6+ in the path as `python3`.  Note that `python3` does _not_ have to be your default python, it just has to be installed.
 
-Although allgit is self-contained other than the Python standard library, cloning this repository is recommended so it can all be kept up-to-date:
+Simply `pip install allgit`  _(( Not actually true yet! ))_
 
-`$ git clone https://github.com/inventhouse/allgit.git`
-
-The allgit directory can then be added to the path and the command aliased to make it as easy to use as possible; add these to your `~/.bash_profile` or preferred shell's config file:
-
-`export PATH=$PATH:/path/to/allgit`
+Aliasing `allgit` to make it as easy as possible to use is also recommended; add this to your `~/.bash_profile` or preferred shell's config file:
 
 `alias ag='allgit'`
 
@@ -82,11 +78,11 @@ On the other hand, we often work with varied repositories that may branch for re
 
 Allgit's `--checkout --branches` (`-cb`) was literally made for this.  By specifying a list of branches in last-one-wins order, a single command can ensure that all the projects are coherent.
 
-For example, say we have a bunch of repositories that integrate together: some have branched for 'SpamRelease', one works from a 'development' branch, we have a feature branch across a few, and the rest should be on 'master', we could simply run:
+For example, say we have a complex group of repositories that integrate together: we have a feature branch across a few, some have branched for 'SpamRelease', many have 'main' as their primary branch, and one still uses 'master', we could simply run:
 
-`$ allgit -cb master SpamRelease development my_feature`
+`$ allgit -cb my_feature SpamRelease main master`
 
-We can even add a ` - pull -r` to the end to pull them up-to-date after everything is on the right branch.
+Allgit will check out the right branches in the projects that have them; we can even add a ` - pull -r` to the end to ensure they're all up-to-date.
 
 
 Finding and Filtering

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ It also serves as a platform for other scripts - if we can write a script that w
 
 Setup
 -----
-_(( Is this going to be needed in a packaged world? ))_ Allgit expects to find Python 3.6+ in the path as `python3`.  Note that `python3` does _not_ have to be your default python, it just has to be installed.
-
-Simply `pip install allgit`  _(( Not actually true yet! ))_
+Simply `pip install allgit`
 
 Aliasing `allgit` to make it as easy as possible to use is also recommended; add this to your `~/.bash_profile` or preferred shell's config file:
 

--- a/TODO.md
+++ b/TODO.md
@@ -37,14 +37,10 @@ To Do
   - nitty-gritty details
     - path normalization (all paths that point to the same file get normalized to the first version)
     - symlinks are not followed by find, but are by normalizer
-- DONE: note about python versions, anaconda environments, and link to docs
+  - DONE: note about python versions, anaconda environments, and link to docs
+  - Some description about allgit's philosophy and why I like it better than other solutions
 
 - develop demo - add `help` target to makefiles
-
-- change `-cb` to first-branch-wins
-  - update README
-  - update help
-  - update both checkout and ALLGIT_BRANCH in `process_repo`
 
 - more testing
   - create test assets
@@ -57,6 +53,7 @@ To Do
   - test symlinks vs. find_repos vs. --exclude vs. doing the same repo twice
 
 - pylint (and rules to make pylint reasonable)
+- package for PyPI
 
 - more/better error handling (catch exceptions and do something nicer with them)
   - DONE: trying to run existing script that lacks execute permission throws PermissionError
@@ -69,7 +66,7 @@ To Do
 
 - `pleasemake` helper - make a target in repos where it can be easily found in the Makefile - or checkmake for use with -t?
 - PUNT: use `hub` - `pushpr` helper to actually create PRs from pushed branch (or `open` the PR pages so you can add comments, reviewers, etc - linux version of `open`?)
-- `githubclone` helper to mass-clone github repos - build one of these on `hub`
+- PUNT: `githubclone` helper to mass-clone github repos - build one of these on `hub`
 
 - `-t/--tags` - basically just like --branches but different mechanism
     - should this have a checkout mode too?
@@ -185,5 +182,10 @@ To Do
   - PUNT: repos list? (never actually used that, maybe a "just print repos" flag/mode would be better) - not fully known
   - could some / all of these be "passed" to scripts as env vars? - might make it easier to write "subcommands"
     - sentinel var scripts could check for and print usage?
+
+- DONE: change `-cb` to first-branch-wins
+  - DONE: update README
+  - DONE: update help
+  - DONE: update both checkout and ALLGIT_BRANCH in `process_repo`
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,7 @@ To Do
   - how to unit test all this?
   - add more tests as new features are added
   - test symlinks vs. find_repos vs. --exclude vs. doing the same repo twice
+  - look into https://pypi.org/project/fixtures-git/
 
 - pylint (and rules to make pylint reasonable)
 - package for PyPI

--- a/allgit
+++ b/allgit
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) 2018-2021 Benjamin Holt -- MIT License
 
+##########
+# DEPRECATED: This copy is just for backward-compatiblity, the current version is 'allgit.py'
+# THIS COPY WILL BE DELETED at some point
+##########
+
 """
 Lightweight tool to work with many git repositories.
 """

--- a/allgit.py
+++ b/allgit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018-2019 Benjamin Holt -- MIT License
+# Copyright (c) 2018-2021 Benjamin Holt -- MIT License
 
 """
 Lightweight tool to work with many git repositories.
@@ -17,9 +17,9 @@ import sys
 
 ###  Main  ###
 _name = "allgit"
-_version = "v0.9"
+_version = "1.0"
 
-def main(args, env):
+def main(args=sys.argv, env=os.environ):
     "Handle arguments, etc."
     git_tool = env.get("ALLGIT_GIT_TOOL", "git")
     mine, delim, cmd = split_args(args[1:], delims=("-", "--"))
@@ -27,7 +27,7 @@ def main(args, env):
         cmd[0:0] = [git_tool]  # ...and may omit "git" which feels redundant on the command line
     # Non-git command must be separated by '--', but doesn't get anything magically added
 
-    usage = f"""                                                       {_version}
+    usage = f"""                                                      v{_version}
     \t{_name} [DIR ...] [options] [- [{git_tool}] SUBCOMMAND]
     \t{_name} [DIR ...] [options] [-- ANY COMMAND]
     \t{_name} -h/--help"""
@@ -83,7 +83,7 @@ def main(args, env):
         "-b", "--branches",
         nargs="+",
         metavar="B",
-        help="Only work on repositories which have at least one of these branches.",
+        help="Only work on repositories which have at least one of these branches; branches should be given in first-one-wins priority order.",
     )
     filter_group.add_argument(
         "-m", "--modified",
@@ -106,7 +106,7 @@ def main(args, env):
     actions_group.add_argument(
         "-c", "--checkout",
         action="store_true",
-        help="Check out the requested branches in the repositories that have them, the last branch found is the one checked out; has no effect if no branches are specified.",
+        help="Check out the requested branches in the repositories that have them; branches should be given in first-one-wins priority order.  Has no effect if no branches are specified.",
     )
     actions_group.add_argument(
         "-l", "--list",
@@ -308,7 +308,7 @@ def process_repo(repo, errors, cmd=None, fetch=False, test_cmd=None, branches=No
         print(f"Found branches: {', '.join(found_branches)}")
 
     if checkout and found_branches:
-        checkout_cmd = ["git", "checkout", found_branches[-1]]
+        checkout_cmd = ["git", "checkout", found_branches[0]]
         ok = repo_run(repo, checkout_cmd, errors=errors, print_cmd=print_cmd, dry_run=dry_run)
         if not ok:
             return False
@@ -317,7 +317,7 @@ def process_repo(repo, errors, cmd=None, fetch=False, test_cmd=None, branches=No
         env = None
         if found_branches:  # Make requested branch available to the command
             env = dict(os.environ)
-            env["ALLGIT_BRANCH"] = found_branches[-1]
+            env["ALLGIT_BRANCH"] = found_branches[0]
         ok = repo_run(repo, cmd, env=env, errors=errors, print_cmd=print_cmd, dry_run=dry_run)
         if not ok:
             return False
@@ -553,6 +553,6 @@ def tput(capname, *params):
 
 #####
 if __name__ == "__main__":
-    _xit = main(sys.argv, os.environ)  # pylint: disable=invalid-name
+    _xit = main()  # pylint: disable=invalid-name
     sys.exit(_xit)
 #####

--- a/allgit.py
+++ b/allgit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018-2021 Benjamin Holt -- MIT License
+# Copyright (c) 2018-2019 Benjamin Holt -- MIT License
 
 """
 Lightweight tool to work with many git repositories.
@@ -193,10 +193,6 @@ def main(args, env):
 
     if not my_args.list:
         print(f"{tput('bold')}Done.{tput('sgr0')}")
-
-    print(f"{tput('bold')}WARNING:{tput('sgr0')} allgit v1.0 has been migrated to PyPI and should be installed with 'pip install allgit'; this copy is deprecated and will be removed.")
-    print(f"{tput('bold')}NOTE:{tput('sgr0')} allgit v1.0 and later REVERSES branches priority order, going forward branches will be treated as first-one-wins")
-
     return xit
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,15 @@ from allgit import _version
 
 
 #####
+with open("README.md", "r") as f:
+    long_description = f.read()
+
 setup(
     name="allgit",
     version=_version,
     description="""Powerful "git multiplexer" for easily working with many repositories""",
-    long_description="FIXME: See readme for now",
+    long_description=long_description,  # FIXME: Do something better than just dumping the whole readme
+    long_description_content_type="text/markdown",
     url="https://github.com/inventhouse/allgit",
     author="Benjamin Holt",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 from setuptools import setup
 
 from allgit import _version
+#####
 
+
+#####
 setup(
     name="allgit",
     version=_version,
@@ -20,13 +23,14 @@ setup(
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Operating System :: Unix',
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Operating System :: Unix",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3.6",
-        'Topic :: Software Development :: Version Control',
+        "Topic :: Software Development :: Version Control",
     ],
     keywords="git",
 )
+#####

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 Benjamin Holt -- MIT License
+
+from setuptools import setup
+
+from allgit import _version
+
+setup(
+    name="allgit",
+    version=_version,
+    description="""Powerful "git multiplexer" for easily working with many repositories""",
+    long_description="FIXME: See readme for now",
+    url="https://github.com/inventhouse/allgit",
+    author="Benjamin Holt",
+    license="MIT",
+    py_modules=["allgit"],
+    entry_points={
+        "console_scripts": [
+            "allgit=allgit:main",
+        ],
+    },
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Operating System :: Unix',
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.6",
+        'Topic :: Software Development :: Version Control',
+    ],
+    keywords="git",
+)


### PR DESCRIPTION
Re-organize allgit to publish on PyPI, now available at https://pypi.org/project/allgit/

Note: this also _reversed_ the priority order of `--branches/-b`, this transition seemed to be a good time to introduce this breaking change.